### PR TITLE
Fix EOF handling of the last chunk of the message.

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -537,7 +537,7 @@ type cachingReadCloser struct {
 func (r *cachingReadCloser) Read(p []byte) (n int, err error) {
 	n, err = r.R.Read(p)
 	r.buf.Write(p[:n])
-	if err == io.EOF {
+	if err == io.EOF || err == nil && n < len(p) {
 		r.OnEOF(bytes.NewReader(r.buf.Bytes()))
 	}
 	return n, err


### PR DESCRIPTION
This problem surfaces when using a transport with gzip handling turned on.

The change satisfies the following specifics of end-of-file conditions per docs:
```
// When Read encounters an error or end-of-file condition after
// successfully reading n > 0 bytes, it returns the number of
// bytes read. It may return the (non-nil) error from the same call
// or return the error (and n == 0) from a subsequent call.
// An instance of this general case is that a Reader returning
// a non-zero number of bytes at the end of the input stream may
// return either err == EOF or err == nil. The next Read should
// return 0, EOF.
```